### PR TITLE
Remove pub.dev publishing support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Release Pub Package
-description: Release a flutter/dart package to pub and on Github
+description: Release a flutter/dart package on Github
 
 runs:
   using: node12
@@ -25,45 +25,4 @@ inputs:
 
   post-release-command:
     description: 'Commands to run after publishing the release on Github'
-    required: false
-
-  pre-publish-command:
-    description: 'Commands to run before publishing to pub.dev'
-    required: false
-
-  post-publish-command:
-    description: 'Commands to run after publishing to pub.dev'
-    required: false
-  
-  should-run-pub-score-test:
-    description: 'Whether to run pana tests, used by pub.dev to determine package score'
-    required: false
-    default: false
-
-  pub-score-min-points:
-    description: 'Minimum required points (out of 100) to pass the pub score test'
-    required: false
-  
-  access-token:
-    description: 'The access token required to authenticate with the pub tool'
-    required: false
-  
-  refresh-token:
-    description: 'The refresh token required to authenticate with the pub tool'
-    required: false
-  
-  id-token:
-    description: 'The id token required to authenticate with the pub tool'
-    required: false
-  
-  token-endpoint:
-    description: 'The token endpoint required to authenticate with the pub tool'
-    required: false
-  
-  expiration:
-    description: 'The expiration value required to authenticate with the pub tool'
-    required: false
-  
-  pub-credentials-file:
-    description: 'The credentials file to be used to authorize with pub'
     required: false

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,9 @@
 import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as github from '@actions/github'
-import * as tc from '@actions/tool-cache'
 import { Octokit } from '@octokit/action'
 import parseChangelog from 'changelog-parser'
 import fs from 'fs'
-
-// Latest Stable Flutter Version (at the time of release) that support all required features.
-
-const flutterWinDownloadUrl = 'https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_3.22.2-stable.zip'
-const flutterMacOSDownloadUrl = 'https://storage.googleapis.com/flutter_infra/releases/stable/macos/flutter_macos_3.22.2-stable.zip'
-const flutterLinuxDownloadUrl = 'https://storage.googleapis.com/flutter_infra/releases/stable/linux/flutter_linux_3.22.2-stable.tar.xz'
 
 async function run() {
    const octokit = new Octokit()
@@ -51,17 +44,12 @@ async function run() {
       preReleaseCommand: inputs.preReleaseCommand,
       postReleaseCommand: inputs.postReleaseCommand,
       isDraft: inputs.isDraft,
-      version: version,
-      body: body
+      version,
+      body
    })
 
-   // Set up the Flutter SDK
-
-   await setUpFlutterSDK()
-
-   // Publish package
-
-   await publishPackageToPub(inputs)
+   // This Github action no longer supports publishing to pub.dev
+   // Please see https://dart.dev/tools/pub/automated-publishing#triggering-automated-publishing-from-github-actions
 }
 
 process.on('unhandledRejection', err => { throw err })
@@ -82,18 +70,6 @@ async function getActionInputs(octokit) {
 
       inputs.preReleaseCommand = core.getInput('pre-release-command')
       inputs.postReleaseCommand = core.getInput('post-release-command')
-
-      inputs.prePublishCommand = core.getInput('pre-publish-command')
-      inputs.postPublishCommand = core.getInput('post-publish-command')
-
-      inputs.shouldRunPubScoreTest = core.getInput('should-run-pub-score-test').toUpperCase() === 'TRUE'
-      inputs.pubScoreMinPoints = Number.parseInt(core.getInput('pub-score-min-points'))
-
-      inputs.accessToken = core.getInput('access-token')
-      inputs.refreshToken = core.getInput('refresh-token')
-      inputs.idToken = core.getInput('id-token')
-      inputs.tokenEndpoint = core.getInput('token-endpoint')
-      inputs.expiration = core.getInput('expiration')
 
       inputs.pubCredentialsFile = core.getInput('pub-credentials-file')
    } catch (err) {
@@ -167,123 +143,10 @@ async function createRelease(octokit = new Octokit(), {
       name: `v${version}`,
       tag_name: `v${version}`,
       target_commitish: github.context.sha,
-      body: body,
+      body,
       draft: isDraft,
       prerelease: version.includes('-')
    })
 
    await execCommand(postReleaseCommand)
-}
-
-async function setUpFlutterSDK() {
-   core.exportVariable('FLUTTER_ROOT', `${process.env.HOME}/flutter`)
-
-   const cachedTool = tc.find('flutter', '2.x')
-
-   if (!cachedTool) {
-      if (process.platform === 'win32') {
-         const flutterPath = await tc.downloadTool(flutterWinDownloadUrl)
-         await tc.extractZip(flutterPath, process.env.HOME)
-
-         tc.cacheDir(process.env.FLUTTER_ROOT, 'flutter', '2.0.3')
-      } else if (process.platform === 'darwin') {
-         const flutterPath = await tc.downloadTool(flutterMacOSDownloadUrl)
-         await tc.extractZip(flutterPath, process.env.HOME)
-
-         tc.cacheDir(process.env.FLUTTER_ROOT, 'flutter', '2.0.3')
-      } else {
-         const flutterPath = await tc.downloadTool(flutterLinuxDownloadUrl)
-         await tc.extractTar(flutterPath, process.env.HOME, 'x')
-
-         tc.cacheDir(process.env.FLUTTER_ROOT, 'flutter', '2.0.3')
-      }
-   }
-
-   core.addPath(`${cachedTool || process.env.FLUTTER_ROOT}/bin`)
-}
-
-async function publishPackageToPub(inputs) {
-   await execCommand(inputs.prePublishCommand)
-
-   if (inputs.shouldRunPubScoreTest) await runPanaTest(inputs.pubScoreMinPoints)
-
-   // Setup auth for pub
-
-   setUpPubAuth({
-      accessToken: inputs.accessToken,
-      refreshToken: inputs.refreshToken,
-      idToken: inputs.idToken,
-      tokenEndpoint: inputs.tokenEndpoint,
-      expiration: inputs.expiration,
-      pubCredentialsFile: inputs.pubCredentialsFile
-   })
-
-   await exec.exec('flutter', ['pub', 'publish', '--force'])
-
-   await execCommand(inputs.postPublishCommand)
-}
-
-function setUpPubAuth({
-   accessToken,
-   refreshToken,
-   idToken,
-   tokenEndpoint,
-   expiration,
-   pubCredentialsFile
-}) {
-   if (!(
-      (accessToken && refreshToken && idToken && tokenEndpoint && expiration) ||
-      pubCredentialsFile
-   )) core.setFailed('Neither tokens nor the credential file was found to authorize with pub')
-
-   const credentials = pubCredentialsFile || {
-      accessToken: accessToken,
-      refreshToken: refreshToken,
-      idToken: idToken,
-      tokenEndpoint: tokenEndpoint,
-      scopes: [
-         'openid',
-         'https://www.googleapis.com/auth/userinfo.email'
-      ],
-      expiration: Number.parseInt(expiration)
-   }
-
-   if (process.platform === 'win32') {
-      const pubCacheDir = `${process.env.APPDATA}/Pub/Cache`
-
-      if (!fs.existsSync(pubCacheDir)) fs.mkdirSync(pubCacheDir)
-
-      fs.writeFileSync(`${pubCacheDir}/credentials.json`, JSON.stringify(credentials))
-   } else {
-      const pubCacheDir = `${process.env.FLUTTER_ROOT}/.pub-cache`
-
-      if (!fs.existsSync(pubCacheDir)) fs.mkdirSync(pubCacheDir)
-
-      fs.writeFileSync(`${pubCacheDir}/credentials.json`, JSON.stringify(credentials))
-   }
-}
-
-async function runPanaTest(pubScoreMinPoints) {
-   let panaOutput = ''
-
-   await exec.exec('flutter', ['pub', 'global', 'activate', 'pana'])
-
-   await exec.exec('flutter', ['pub', 'global', 'run', 'pana', process.env.GITHUB_WORKSPACE, '--json', '--no-warning'], {
-      listeners: {
-         stdout: data => { if (data.toString()) panaOutput += data.toString() }
-      }
-   })
-
-   if (panaOutput.includes('undefined')) panaOutput = panaOutput.replace('undefined', '')
-
-   const panaResult = JSON.parse(panaOutput)
-
-   if (isNaN(pubScoreMinPoints)) core.setFailed('run-pub-score-test was set to true but no value for pub-score-min-points was provided')
-
-   if (panaResult.scores.grantedPoints < pubScoreMinPoints) {
-      for (const test in panaResult.report.sections) {
-         if (test.status !== 'passed') core.warning(test.title + '\n\n\n' + test.summary)
-      }
-      core.error('Pub score test failed')
-   }
 }


### PR DESCRIPTION
## Breaking Change

Is this a breaking change? Did you modify or delete any public APIs in such a way that the package user has to make changes in their code to upgrade to the new version?

I have modified or deleted the following public APIs which will break the users' code - 
  1. Removed support for publishing package to pub.dev
See https://dart.dev/tools/pub/automated-publishing#triggering-automated-publishing-from-github-actions
